### PR TITLE
Update SugarModules/modules/Asterisk/language/ru_ru.lang.php

### DIFF
--- a/SugarModules/modules/Asterisk/language/ru_ru.lang.php
+++ b/SugarModules/modules/Asterisk/language/ru_ru.lang.php
@@ -33,7 +33,7 @@
  */
 if(!defined('sugarEntry') || !sugarEntry) die('Not A Valid Entry Point');
 
-$mod_strings = array (
+$mod_strings = array ( 'YAAI' => array(
 
    	'ASTERISKLBL_COMING_IN' 		=>	'Входящий звонок',
 	'ASTERISKLBL_GOING_OUT' 		=>	'Исходящий звонок',
@@ -72,7 +72,7 @@ $mod_strings = array (
 	'CALL_DESCRIPTION_CALLER_ID'    => 'Номер звонившего',
 	'CALL_DESCRIPTION_MISSED'       => 'Пропущенный/неудачный звонок',
 	'CALL_DESCRIPTION_PHONE_NUMBER' => 'Номер телефона'
-
+)
    );
 
 ?>


### PR DESCRIPTION
This language array called from controller.php 
in function build_item_list(...,$mod_strings) 
`$call = array(...
 'mod_strings' => $mod_strings['YAAI'] //<--- this!
)`

in ru_ru.lang.php is defined as simple array(). 

but we need `array('YAAI' => array()))`
