### PR TITLE
Load external JS via https

### DIFF
--- a/SugarModules/modules/Asterisk/include/AsteriskJS.php
+++ b/SugarModules/modules/Asterisk/include/AsteriskJS.php
@@ -125,7 +125,7 @@ class AsteriskJS {
                         echo '<link rel="stylesheet" href="custom/modules/Asterisk/include/javascript/offlineMode/jquery-ui.css" />';
                     } else {
 
-                        echo '<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/themes/redmond/jquery-ui.css" />';
+                        echo '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/themes/redmond/jquery-ui.css" />';
                     }
                 }
 


### PR DESCRIPTION
This is just a small improvement. I noticed Chrome was complaining about this lib because I access my sugar instance via https.  I noticed all the other references were already using https links. 
